### PR TITLE
add "Edit a survey" guide

### DIFF
--- a/content/docs/survey-editor/basics/editor-overview.mdx
+++ b/content/docs/survey-editor/basics/editor-overview.mdx
@@ -118,7 +118,7 @@ This section shows the survey items that you have added and configured. It inclu
 - Lists current **context variables** and their values. These variables influence logic and conditional rendering of survey items. You can edit the context variables by clicking on the pencil. 
 [See this example on setting participant flags.](/docs/survey-editor/guides/show-part-flag-question#show-a-question-based-on-a-participant-flag)
 
-####Customize Labels
+#### Customize Labels
 - Configure the labels for navigation buttons, including:
   - **Next button**
   - **Back button**

--- a/content/docs/survey-editor/guides/edit-survey.mdx
+++ b/content/docs/survey-editor/guides/edit-survey.mdx
@@ -1,0 +1,33 @@
+---
+title: Edit a Survey
+description: How to edit an existing survey
+---
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+
+<Steps>
+<Step>
+
+Go to **"Standalone editor"**.
+
+</Step>
+<Step>
+
+Choose section **"Survey editor"**.
+
+</Step>
+<Step>
+
+Click the **"Open survey"** button.
+
+</Step>
+<Step>
+
+A dialog appears where you can either upload a survey file from your computer or choose one from the list of recently opened surveys. Select the desired file and click **"Open"** to load it into the editor. If local variables are used, you can rename them before opening the survey.
+
+</Step>
+
+
+![Screenshot of survey editor welcome menu](../images/welcomeEditor.png)
+</Steps>
+You are now ready to edit your survey! Learn how to [configure the editor interface](/docs/survey-editor/basics/editor-overview#survey-editor-dashboard) or [save your changes](/docs/survey-editor/guides/save-survey).
+

--- a/content/docs/survey-editor/guides/meta.json
+++ b/content/docs/survey-editor/guides/meta.json
@@ -1,6 +1,7 @@
 {
     "pages": [
         "setup-survey",
+        "edit-survey",
         "add-single-choice",
         "create-group",
         "add-conditional-question",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added a step-by-step guide for editing an existing survey in the standalone editor, including opening a survey via dialog (upload or recent files), optional variable renaming, a screenshot of the welcome menu, and links to configuring the interface and saving changes.
  * Updated navigation to include the new guide in the Survey Editor guides list.
  * Fixed a minor header spacing issue in an overview page for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->